### PR TITLE
Add julia onthefly dataset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
     actions: write 
 
 jobs: 
-    test:
+    test_julia:
         runs-on: ${{ matrix.os }}
         strategy:
           matrix:
@@ -33,3 +33,25 @@ jobs:
             - uses: julia-actions/julia-runtest@v1
               with:
                 project: QuantumGrav.jl
+            # add coverage report
+
+    test_python:
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            python-version: ['3.10', '3.11']
+            os: [ubuntu-latest, windows-latest, macOS-latest]
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v4
+              with:
+                python-version: ${{ matrix.python-version }}
+            - name: Install dependencies
+              run: |
+                python -m pip install --upgrade pip
+                pip install -e .QuantumGravPy[dev]
+            - name: Run tests
+              run: |
+                pytest QuantumGravPy/test --cov=QuantumGravPy --cov-report=xml 
+            # add coverage report
+            

--- a/QuantumGravPy/pyproject.toml
+++ b/QuantumGravPy/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["hatchling >= 1.26"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/QuantumGrav"]
+
+[project]
+name = "QuantumGrav"
+version = "0.1.0"
+description = "Graph neural networks for the causal set approach to quantum gravity"
+authors = [
+    { name = "Harald Mack", email = "harald.mack@protonmail.com" },
+]
+requires-python = ">= 3.12"
+license = { file = "../LICENSE"} 
+readme = { file = "../README.md", content-type = "text/markdown" }
+
+dependencies = [
+    "torch>=2.7.1", 
+    "torchaudio>=2.7.1",
+    "torchvision>=0.22.1",
+    "torch_scatter>=2.1.2",
+    "torch_sparse>=0.6.18",
+    "torch_cluster>=1.6.3",
+    "torch_spline_conv>=1.2.2",
+    "pyg_lib>=0.4.0",
+    "torch-geometric>=2.6.1",
+    "torchviz>=0.0.3",
+    "h5py>=3.14.0",
+    "pandas>=2.3.0",
+    "seaborn>=0.13.2",
+    "matplotlib>=3.10.3",
+    "scikit-learn>=1.7.0",
+    "juliacall>=0.9.25"
+]
+
+# Optional dependencies
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+    "ruff",
+    "mypy",
+]
+
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+    "-vvv",
+    "-s",
+]

--- a/QuantumGravPy/src/QuantumGrav/__init__.py
+++ b/QuantumGravPy/src/QuantumGrav/__init__.py
@@ -1,0 +1,7 @@
+from .julia_worker import JuliaWorker
+from .dataset_onthefly import QGDatasetOnthefly
+
+__all__ = [
+    "QGDatasetOnthefly",
+    "JuliaWorker",
+]

--- a/QuantumGravPy/src/QuantumGrav/dataset_onthefly.py
+++ b/QuantumGravPy/src/QuantumGrav/dataset_onthefly.py
@@ -1,0 +1,106 @@
+from . import julia_worker as jl_worker
+
+# pytorch and torch geometric imports
+from torch_geometric.data import Data, Dataset
+import sys
+
+# system imports and quality of life tools
+from pathlib import Path
+from collections.abc import Callable
+from typing import Any
+from joblib import Parallel, delayed
+
+
+class QGDatasetOnthefly(Dataset):
+    """A dataset that generates data on the fly using a Julia function.
+
+    Args:
+        Dataset (Dataset): The base dataset class.
+    """
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        jl_code_path: str | Path | None = None,
+        jl_func_name: str | None = None,
+        jl_module_name: str | None = None,
+        jl_base_module_path: str | Path | None = None,
+        jl_dependencies: list[str] | None = None,
+        transform: Callable[[dict[Any, Any]], Data] | None = None,
+        converter: Callable[[Any], Any] | None = None,
+    ):
+        if transform is None:
+            raise ValueError(
+                "Transform function must be provided to turn raw data dictionaries into PyTorch Geometric Data objects."
+            )
+        self.transform = transform
+
+        if converter is None:
+            raise ValueError(
+                "Converter function must be provided to convert Julia objects into standard Python objects."
+            )
+        else:
+            self.converter = converter
+
+        self.config = config
+        self.databatch: list[Data] = []  # hold a batch of generated data
+
+        try:
+            self.worker = jl_worker.JuliaWorker(
+                config,
+                jl_code_path,
+                jl_func_name,
+                jl_module_name,
+                jl_base_module_path,
+                jl_dependencies,
+            )
+            print("done")
+        except Exception as e:
+            raise RuntimeError(f"Error initializing Julia process: {e}") from e
+
+        super().__init__(None, transform=transform, pre_transform=None, pre_filter=None)
+
+    def len(self) -> int:
+        """Return the length of the dataset.
+
+        Returns:
+            int: The number of samples in the dataset.
+        """
+        return sys.maxsize
+
+    def make_batch(self, size: int) -> list[Data]:
+        return [self.get(i) for i in range(size)]
+
+    def get(self, _: int) -> Data:
+        # this breaks the contract of the 'get'method that the base class provides, but
+        # it nevertheless is useful to generate training data
+        if self.worker is None:
+            raise RuntimeError("Worker process is not initialized.")
+
+        if len(self.databatch) == 0:
+            # Call the Julia function to get the data
+            raw_data = [
+                self.converter(x) for x in self.worker(self.config["batch_size"])
+            ]
+            if isinstance(raw_data, Exception):
+                raise raw_data
+            try:
+                # parallel processing in Julia is handled on the Julia side
+                # use primitve indexing here to avoid issues with julia arrays
+                if self.config["n_processes"] > 1:
+                    self.databatch = Parallel(
+                        n_jobs=self.config["n_processes"], verbose=10
+                    )(
+                        delayed(self.transform)(raw_data[i])
+                        for i in range(len(raw_data))
+                    )
+                else:
+                    self.databatch = [
+                        self.transform(raw_data[i]) for i in range(len(raw_data))
+                    ]
+            except Exception as e:
+                raise RuntimeError(f"Error transforming data: {e}") from e
+
+        datapoint = self.databatch.pop()
+
+        return datapoint

--- a/QuantumGravPy/src/QuantumGrav/dataset_onthefly.py
+++ b/QuantumGravPy/src/QuantumGrav/dataset_onthefly.py
@@ -22,8 +22,7 @@ class QGDatasetOnthefly(Dataset):
         self,
         config: dict[str, Any],
         jl_code_path: str | Path | None = None,
-        jl_func_name: str | None = None,
-        jl_module_name: str | None = None,
+        jl_constructor_name: str | None = None,
         jl_base_module_path: str | Path | None = None,
         jl_dependencies: list[str] | None = None,
         transform: Callable[[dict[Any, Any]], Data] | None = None,
@@ -49,8 +48,7 @@ class QGDatasetOnthefly(Dataset):
             self.worker = jl_worker.JuliaWorker(
                 config,
                 jl_code_path,
-                jl_func_name,
-                jl_module_name,
+                jl_constructor_name,
                 jl_base_module_path,
                 jl_dependencies,
             )

--- a/QuantumGravPy/src/QuantumGrav/julia_worker.py
+++ b/QuantumGravPy/src/QuantumGrav/julia_worker.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+from typing import Any
+
+
+class JuliaWorker:
+    """_summary_"""
+
+    jl_code_path = None
+    jl_func_name = None
+    jl_module_name = None
+    jl_base_module_path = None
+
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        jl_code_path: str | Path | None = None,
+        jl_func_name: str | None = None,
+        jl_module_name: str | None = None,
+        jl_base_module_path: str | Path | None = None,
+        jl_dependencies: list[str] | None = None,
+    ):
+        """_summary_
+
+        Args:
+            config (dict[str, Any] | None, optional): _description_. Defaults to None.
+            jl_code_path (str | Path | None, optional): _description_. Defaults to None.
+            jl_func_name (str | None, optional): _description_. Defaults to None.
+            jl_module_name (str | None, optional): _description_. Defaults to None.
+            jl_base_module_path (str | Path | None, optional): _description_. Defaults to None.
+            jl_dependencies (list[str] | None, optional): _description_. Defaults to None.
+
+        Raises:
+            ValueError: _description_
+            ValueError: _description_
+            FileNotFoundError: _description_
+            ValueError: _description_
+            NotImplementedError: _description_
+            RuntimeError: _description_
+            RuntimeError: _description_
+            RuntimeError: _description_
+        """
+        import juliacall as jcall
+
+        if jl_func_name is None:
+            raise ValueError("Julia function name must be provided.")
+
+        if jl_code_path is None:
+            raise ValueError("Julia code path must be provided.")
+
+        jl_code_path = Path(jl_code_path).resolve().absolute()
+        if not jl_code_path.exists():
+            raise FileNotFoundError(f"Julia code path {jl_code_path} does not exist.")
+
+        if jl_module_name is None:
+            jl_module_name = jl_code_path.stem
+
+        self.jl_code_path = str(jl_code_path)
+        self.jl_func_name = jl_func_name
+        self.jl_module_name = jl_module_name
+        self.jl_base_module_path = str(Path(jl_base_module_path).resolve().absolute())
+
+        try:
+            self.jl_module = jcall.newmodule(jl_module_name)
+        except Exception as e:
+            raise ValueError(
+                f"Error creating Julia module {jl_module_name}: {e}"
+            ) from e
+
+        # add base module for dependencies
+        if jl_base_module_path is None:
+            raise NotImplementedError("Base module path must be provided at the moment")
+        else:
+            try:
+                self.jl_module.seval(
+                    f'using Pkg; Pkg.develop(path="{jl_base_module_path}")'
+                )  # only for now -> get from package index later
+
+            except Exception as e:
+                raise RuntimeError(
+                    f"Error loading base module {jl_base_module_path}: {e}"
+                ) from e
+
+        try:
+            # add dependencies if provided\
+            if jl_dependencies is not None:
+                for dep in jl_dependencies:
+                    self.jl_module.seval(f'using Pkg; Pkg.add("{dep}")')
+        except Exception as e:
+            raise RuntimeError(f"Error loading Julia dependencies: {e}") from e
+
+        try:
+            # load the julia data generation julia code
+            self.jl_module.seval(f'push!(LOAD_PATH, "{jl_code_path}")')
+            self.jl_module.seval("using QuantumGrav")
+            self.jl_module.seval(f'include("{jl_code_path}")')
+
+            generator_constructor = getattr(self.jl_module, jl_func_name)
+
+            self.jl_generator = generator_constructor(config)
+        except Exception as e:
+            raise RuntimeError(
+                f"Error loading Julia module {jl_module_name}: {e}"
+            ) from e
+
+    def __call__(self, n: int):
+        """_summary_
+
+        Raises:
+            RuntimeError: _description_
+
+        Returns:
+            _type_: _description_
+        """
+        if self.jl_module is None:
+            raise RuntimeError("Julia module is not initialized.")
+        raw_data = self.jl_generator(n)
+        return raw_data

--- a/QuantumGravPy/test/conftest.py
+++ b/QuantumGravPy/test/conftest.py
@@ -1,0 +1,84 @@
+import pytest
+import juliacall as jcall
+
+import torch
+from torch_geometric.data import Data
+from torch_geometric.utils import dense_to_sparse
+
+
+@pytest.fixture
+def basic_transform():
+    def transform(raw: jcall.DictValue) -> Data:
+        # this function will transform the raw data dictionary from Julia into a PyTorch Geometric Data object. Hence, we have to deal with julia objects here
+        adj_raw = raw["adjacency_matrix"]
+        adj_matrix = torch.tensor(adj_raw, dtype=torch.float32)
+        edge_index, edge_weight = dense_to_sparse(adj_matrix)
+        adj_matrix = adj_matrix.to_sparse()
+
+        node_features = []
+
+        max_path_future = torch.tensor(
+            raw["max_pathlen_future"], dtype=torch.float32
+        ).unsqueeze(1)  # make this a (num_nodes, 1) tensor
+
+        max_path_past = torch.tensor(
+            raw["max_pathlen_past"], dtype=torch.float32
+        ).unsqueeze(1)  # make this a (num_nodes, 1) tensor
+
+        node_features.extend([max_path_future, max_path_past])
+
+        # Concatenate all node features
+        x = torch.cat(node_features, dim=1)
+        classes = [raw["manifold"], raw["boundary"], raw["dimension"]]
+        y = torch.tensor(classes, dtype=torch.long)
+        data = Data(
+            x=x,
+            edge_index=edge_index,
+            edge_attr=edge_weight,
+            y=y,
+        )
+
+        return data
+
+    return transform
+
+
+@pytest.fixture
+def basic_converter():
+    def converter(raw: jcall.DictValue) -> dict:
+        # convert the raw data dictionary from Julia into a standard Python dictionary
+        return {
+            "manifold": int(raw["manifold"]),
+            "boundary": int(raw["boundary"]),
+            "dimension": int(raw["dimension"]),
+            "atomcount": int(raw["atomcount"]),
+            "adjacency_matrix": raw["adjacency_matrix"].to_numpy(),
+            "link_matrix": raw["link_matrix"].to_numpy(),
+            "max_pathlen_future": raw["max_pathlen_future"].to_numpy(),
+            "max_pathlen_past": raw["max_pathlen_past"].to_numpy(),
+        }
+
+    return converter
+
+
+@pytest.fixture
+def jlcall_args():
+    onthefly_config = {
+        "seed": 42,
+        "n_processes": 1,
+        "batch_size": 5,
+    }
+    return onthefly_config
+
+
+@pytest.fixture
+def jl_vars():
+    return {
+        "jl_code_path": "./QuantumGravPy/test/julia_testmodule.jl",
+        "jl_constructor_name": "Generator",
+        "jl_base_module_path": "./QuantumGrav.jl",
+        "jl_dependencies": [
+            "Distributions",
+            "Random",
+        ],
+    }

--- a/QuantumGravPy/test/julia_testmodule.jl
+++ b/QuantumGravPy/test/julia_testmodule.jl
@@ -1,0 +1,99 @@
+import QuantumGrav as QG
+import Random
+import Distributions
+
+struct Generator
+    seed::Int64
+end
+
+function Generator(config::AbstractDict)
+    return Generator(config["seed"])
+end
+
+# this is a test function to create a single datapoint of a dataset
+function (gen::Generator)(batchsize::Int)
+    manifolds =
+        ["Minkowski", "DeSitter", "AntiDeSitter", "HyperCylinder", "Torus", "Random"]
+    boundaries = ["CausalDiamond", "TimeBoundary", "BoxBoundary"]
+    min_atomcount = 5
+    max_atomcount = 15
+    rng = Random.MersenneTwister(gen.seed)
+    dim_distr = Distributions.DiscreteUniform(2, 4)
+    manifold_distr = Distributions.DiscreteUniform(1, 6)
+    boundary_distr = Distributions.DiscreteUniform(1, 3)
+    atomcount_distr = Distributions.DiscreteUniform(min_atomcount, max_atomcount)
+
+    # make a bunch of datapoints
+    batch = []
+    for _ = 1:batchsize
+        data = Dict{String,Any}()
+        ok = false
+        max_iter = 20
+        type = Float32
+        e = nothing
+        cset = nothing
+        sprinkling = nothing
+        dimension = nothing
+        manifold_id = nothing
+        boundary_id = nothing
+        atomcount = nothing
+        while ok == false && max_iter > 0
+            max_iter -= 1
+            dimension = rand(rng, dim_distr)
+            manifold_id = Distributions.rand(rng, manifold_distr)
+            manifold = manifolds[manifold_id]
+            boundary_id = Distributions.rand(rng, boundary_distr)
+            boundary = boundaries[boundary_id]
+            atomcount = Distributions.rand(rng, atomcount_distr)
+            # make dataset 
+            try
+                # make data needed 
+                cset, sprinkling =
+                    QG.make_cset(manifold, boundary, atomcount, dimension, rng; type = type)
+                ok = true
+                e = nothing
+            catch error
+                ok = false
+                e = error
+                cset = nothing
+                sprinkling = nothing
+            end
+
+            if max_iter <= 0
+                println("Max iterations reached, breaking out of loop.")
+                break
+            end
+        end
+
+        link_matrix = QG.make_link_matrix(cset, type = type)
+        adjacency_matrix = QG.make_adj(cset, type = type)
+        max_pathlen_future = [
+            QG.max_pathlen(adjacency_matrix, collect(1:size(adjacency_matrix, 1)), i)
+            for i = 1:cset.atom_count
+        ]
+        max_pathlen_past = [
+            QG.max_pathlen(adjacency_matrix', collect(1:size(adjacency_matrix, 2)), i)
+            for i = 1:cset.atom_count
+        ]
+
+        data["manifold"] = manifold_id
+        data["boundary"] = boundary_id
+        data["dimension"] = dimension
+        data["atomcount"] = atomcount
+        data["adjacency_matrix"] = Matrix(adjacency_matrix)
+        data["link_matrix"] = Matrix(link_matrix)
+        data["max_pathlen_future"] = max_pathlen_future
+        data["max_pathlen_past"] = max_pathlen_past
+
+        if e !== nothing
+            throw(
+                ErrorException(
+                    "Failed to create a valid causal set after multiple attempts: $e",
+                ),
+            )
+        end
+
+        push!(batch, data)
+    end
+    return batch
+end

--- a/QuantumGravPy/test/test_juliaworker.py
+++ b/QuantumGravPy/test/test_juliaworker.py
@@ -1,0 +1,94 @@
+import QuantumGrav as QG
+import pytest
+from pathlib import Path
+
+
+def test_juliaworker_works(jlcall_args, jl_vars):
+    jlworker = QG.JuliaWorker(
+        jl_kwargs=jlcall_args,
+        **jl_vars,
+    )
+
+    assert jlworker.jl_code_path == str(
+        Path("./QuantumGravPy/test/julia_testmodule.jl").resolve().absolute()
+    )
+    assert jlworker.jl_constructor_name == "Generator"
+    assert jlworker.jl_base_module_path == str(
+        Path("./QuantumGrav.jl").resolve().absolute()
+    )
+
+
+def test_juliaworker_no_funcname(jlcall_args):
+    with pytest.raises(ValueError, match="Julia function name must be provided."):
+        QG.JuliaWorker(
+            jl_kwargs=jlcall_args,
+            jl_code_path="./QuantumGravPy/test/julia_testmodule.jl",
+            jl_constructor_name=None,
+            jl_base_module_path="./QuantumGrav.jl",
+            jl_dependencies=[
+                "Distributions",
+                "Random",
+            ],
+        )
+
+
+def test_juliaworker_no_codepath(jlcall_args):
+    with pytest.raises(ValueError, match="Julia code path must be provided."):
+        QG.JuliaWorker(
+            jl_kwargs=jlcall_args,
+            jl_code_path=None,
+            jl_constructor_name="Generator",
+            jl_base_module_path="./QuantumGrav.jl",
+            jl_dependencies=[
+                "Distributions",
+                "Random",
+            ],
+        )
+
+
+def test_juliaworker_jl_failure(jlcall_args, mocker):
+    # mock the jl_call stuff such that it raises an error
+    mock_module = mocker.MagicMock()
+    mock_module.seval.side_effect = RuntimeError("Julia call failed.")
+
+    # Mock the newmodule function to return our mock module
+    mocker.patch("juliacall.newmodule", return_value=mock_module)
+
+    with pytest.raises(RuntimeError, match="Julia call failed."):
+        QG.JuliaWorker(
+            jl_kwargs=jlcall_args,
+            jl_code_path="./QuantumGravPy/test/julia_testmodule.jl",
+            jl_constructor_name="Generator",
+            jl_base_module_path="./QuantumGrav.jl",
+            jl_dependencies=[
+                "Distributions",
+                "Random",
+            ],
+        )
+
+
+def test_juliaworker_jl_call(jlcall_args):
+    jlworker = QG.JuliaWorker(
+        jl_kwargs=jlcall_args,
+        jl_code_path="./QuantumGravPy/test/julia_testmodule.jl",
+        jl_constructor_name="Generator",
+        jl_base_module_path="./QuantumGrav.jl",
+        jl_dependencies=[
+            "Distributions",
+            "Random",
+        ],
+    )
+
+    batch = jlworker(5)
+    assert len(batch) == 5
+    assert all(
+        key in batch[0]
+        for key in [
+            "manifold",
+            "boundary",
+            "dimension",
+            "atomcount",
+            "adjacency_matrix",
+            "link_matrix",
+        ]
+    )

--- a/QuantumGravPy/test/test_ontheflydataset.py
+++ b/QuantumGravPy/test/test_ontheflydataset.py
@@ -1,0 +1,97 @@
+import QuantumGrav as QG
+import pytest
+from torch_geometric.data import Data
+
+
+def test_onthefly_dataset_creation_works(
+    jlcall_args, jl_vars, basic_transform, basic_converter
+):
+    ontheflydataset = QG.QGDatasetOnthefly(
+        config=jlcall_args,
+        transform=basic_transform,
+        converter=basic_converter,
+        **jl_vars,
+    )
+
+    assert ontheflydataset.worker is not None
+    assert ontheflydataset.transform == basic_transform
+
+    data = ontheflydataset.worker(5)
+
+    assert len(data) == 5
+    assert all(
+        key in data[0]
+        for key in [
+            "manifold",
+            "boundary",
+            "dimension",
+            "atomcount",
+            "adjacency_matrix",
+            "link_matrix",
+        ]
+    )
+    assert ontheflydataset.config == jlcall_args
+    assert ontheflydataset.worker is not None
+
+
+def test_onthefly_dataset_no_transform(jlcall_args):
+    with pytest.raises(
+        ValueError,
+        match="Transform function must be provided to turn raw data dictionaries into PyTorch Geometric Data objects.",
+    ):
+        QG.QGDatasetOnthefly(
+            config=jlcall_args,
+            jl_code_path="./QuantumGravPy/test/julia_testmodule.jl",
+            jl_constructor_name="Generator",
+            jl_base_module_path="./QuantumGrav.jl",
+            jl_dependencies=[
+                "Distributions",
+                "Random",
+            ],
+            transform=None,
+            converter=lambda x: x,
+        )
+
+
+def test_onthefly_dataset_no_converter(jlcall_args):
+    with pytest.raises(
+        ValueError,
+        match="Converter function must be provided to convert Julia objects into standard Python objects.",
+    ):
+        QG.QGDatasetOnthefly(
+            config=jlcall_args,
+            jl_code_path="./QuantumGravPy/test/julia_testmodule.jl",
+            jl_constructor_name="Generator",
+            jl_base_module_path="./QuantumGrav.jl",
+            jl_dependencies=[
+                "Distributions",
+                "Random",
+            ],
+            transform=lambda x: x,
+            converter=None,
+        )
+
+
+@pytest.mark.parametrize("n", [1, 2], ids=["sequential", "parallel"])
+def test_onthefly_dataset_processing(jlcall_args, basic_transform, basic_converter, n):
+    # check that the get function works and returns a viable data object
+    jlcall_args["n_processes"] = n
+
+    ontheflydataset = QG.QGDatasetOnthefly(
+        config=jlcall_args,
+        jl_code_path="./QuantumGravPy/test/julia_testmodule.jl",
+        jl_constructor_name="Generator",
+        jl_base_module_path="./QuantumGrav.jl",
+        jl_dependencies=[
+            "Distributions",
+            "Random",
+        ],
+        transform=basic_transform,
+        converter=basic_converter,
+    )
+
+    datapoint = ontheflydataset.get(0)
+
+    assert isinstance(datapoint, Data)
+    assert datapoint.x.shape[1] == 2  # 2 degrees of freedom
+    assert datapoint.y.shape == (3,)  # manifold, boundary, dimension


### PR DESCRIPTION
- add `juliacall` dependency 
- add a `JuliaWorker` class that handles the bridge to Julia: 
   - Julia code to be executed needs to be a callable object with a call operator with arbitrary args, and a constructor with a set of kwargs
   - instantiating the JuliaWorker will install dependencies, load the `QuantumGrav.jl` module, and provide a call operator that returns julia objects wrapped with the [juliacall python wrappers](https://juliapy.github.io/PythonCall.jl/stable/conversion-to-python/)
   - calling this object will execute the call operator of the underlying julia object with the given args, kwargs and return the result 
  