### PR TITLE
Add zarr file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,10 @@ docs/site/
 Manifest.toml
 
 # Python stuff
-
 .venv
 *.pyc 
 __pycache__/
-.venv/
+*/.venv
 settings.json
 
 # macOS specific files

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ data/
 
 # coverage files
 .coverage*
+
+# ignor experimental dir 
+*/experimental/*

--- a/QuantumGrav.jl/Project.toml
+++ b/QuantumGrav.jl/Project.toml
@@ -15,6 +15,7 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+Zarr = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 
 [sources]
 CausalSets = {url = "https://codeberg.org/cyclopentane/CausalSets.jl"}
@@ -31,3 +32,4 @@ ProgressMeter = "1.10.4"
 Random = "1.11.0"
 SparseArrays = "1.11.0"
 YAML = "0.4.14"
+Zarr = "0.9.4"

--- a/QuantumGrav.jl/src/QuantumGrav.jl
+++ b/QuantumGrav.jl/src/QuantumGrav.jl
@@ -8,6 +8,7 @@ import CausalSets
 import Distributions
 import YAML
 import HDF5
+import Zarr
 import ProgressMeter
 import Dates
 

--- a/QuantumGrav.jl/src/datageneration.jl
+++ b/QuantumGrav.jl/src/datageneration.jl
@@ -508,6 +508,6 @@ function make_data(
 
     if config["output_format"] == "hdf5"
         close(file)
-    end        # nothing to do for Zarr storage mode
+    end        # Zarr stores do not require explicit closing, as they do not maintain open file handles like HDF5 files.
 
 end

--- a/QuantumGrav.jl/test/Project.toml
+++ b/QuantumGrav.jl/test/Project.toml
@@ -11,6 +11,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+Zarr = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 
 [sources]
 CausalSets = {url = "https://codeberg.org/cyclopentane/CausalSets.jl"}

--- a/QuantumGravPy/pyproject.toml
+++ b/QuantumGravPy/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "scikit-learn",
     "joblib",
     "juliacall",
-    "PyYAML"
+    "PyYAML", 
+    "zarr",
 ]
 
 # Optional dependencies

--- a/QuantumGravPy/src/QuantumGrav/dataset_base.py
+++ b/QuantumGravPy/src/QuantumGrav/dataset_base.py
@@ -240,7 +240,7 @@ class QGDatasetBase:
 
     def process_chunk(
         self,
-        store: zarr.storage.LocalStore,
+        store: zarr.storage.LocalStore | h5py.File,
         start: int,
         pre_transform: Callable[[Data], Data] | None = None,
         pre_filter: Callable[[Data], bool] | None = None,

--- a/QuantumGravPy/src/QuantumGrav/dataset_base.py
+++ b/QuantumGravPy/src/QuantumGrav/dataset_base.py
@@ -5,6 +5,7 @@ import torch
 # data handling
 import h5py
 import yaml
+import zarr
 
 # system imports and quality of life tools
 from pathlib import Path
@@ -19,7 +20,11 @@ class QGDatasetBase:
         self,
         input: list[str | Path],
         output: str | Path,
-        reader: Callable[[h5py.File, torch.dtype, torch.dtype, bool], list[Data]]
+        mode: str = "hdf5",
+        reader: Callable[
+            [h5py.File | zarr.abc.store.Store, torch.dtype, torch.dtype, bool],
+            list[Data],
+        ]
         | None = None,
         float_type: torch.dtype = torch.float32,
         int_type: torch.dtype = torch.int64,
@@ -48,6 +53,9 @@ class QGDatasetBase:
         if reader is None:
             raise ValueError("A reader function must be provided to load the data.")
 
+        if mode not in ["hdf5", "zarr"]:
+            raise ValueError("mode must be 'hdf5' or 'zarr'")
+
         self.input = input
         for file in self.input:
             if Path(file).exists() is False:
@@ -61,15 +69,21 @@ class QGDatasetBase:
         self.validate_data = validate_data
         self.n_processes = n_processes
         self.chunksize = chunksize
-        self._num_samples = None
 
         # get the number of samples in the dataset
         self._num_samples = 0
-        for file in self.input:
-            if not Path(file).exists():
-                raise FileNotFoundError(f"Input file {file} does not exist.")
-            with h5py.File(file, "r") as f:
-                self._num_samples += f["num_causal_sets"][()]
+
+        for filepath in self.input:
+            if not Path(filepath).exists():
+                raise FileNotFoundError(f"Input file {filepath} does not exist.")
+
+            if mode == "hdf5":
+                with h5py.File(filepath, "r") as f:
+                    self._num_samples += int(f["num_causal_sets"][()])
+            else:
+                with zarr.storage.LocalStore(filepath, read_only=True) as store:
+                    root = zarr.open_group(store, path="", mode="r")
+                    self._num_samples += int(root["num_samples"][0])
 
         # ensure the input is a list of paths
         if Path(self.processed_dir).exists():
@@ -126,7 +140,7 @@ class QGDatasetBase:
             if f.is_file() and f.suffix == ".pt" and "data" in f.name
         ]
 
-    def process_chunk(
+    def process_chunk_hdf5(
         self,
         raw_file: h5py.File,
         start: int,
@@ -142,10 +156,10 @@ class QGDatasetBase:
             pre_filter (Callable[[Data], bool] | None, optional): A function that filters the data. Defaults to None.
 
         Returns:
-            Data | None: The processed data or None if the chunk is empty.
+            list[Data]: The processed data or None if the chunk is empty.
         """
 
-        # we can't rely on being able to read from the raw_files in parallel, so we need to read the data sequentially
+        # we can't rely on being able to read from the raw_files in parallel, so we need to read the data sequentially first
         data = [
             self.data_reader(
                 raw_file,
@@ -159,25 +173,65 @@ class QGDatasetBase:
             )
         ]
 
+        def process_item(item):
+            if pre_filter is not None and not pre_filter(item):
+                return None
+            if pre_transform is not None:
+                return pre_transform(item)
+            return item
+
         results = []
         if self.n_processes > 1:
-
-            def process_item(item):
-                if pre_filter is not None and not pre_filter(item):
-                    return None
-                if pre_transform is not None:
-                    return pre_transform(item)
-                return item
-
             results = Parallel(n_jobs=self.n_processes)(
                 delayed(process_item)(datapoint) for datapoint in data
             )
-            results = [res for res in results if res is not None]
         else:
-            for datapoint in data:
-                if pre_filter is not None and not pre_filter(datapoint):
-                    continue
-                if pre_transform is not None:
-                    datapoint = pre_transform(datapoint)
-                results.append(datapoint)
-        return results
+            results = [process_item(datapoint) for datapoint in data]
+        return [res for res in results if res is not None]
+
+    def process_chunk_zarr(
+        self,
+        store: zarr.storage.LocalStore,
+        start: int,
+        pre_transform: Callable[[Data], Data] | None = None,
+        pre_filter: Callable[[Data], bool] | None = None,
+    ) -> list[Data]:
+        """Process a chunk of data from the raw file. This method is intended to be used in the data loading pipeline to read a chunk of data, apply transformations, and filter the read data, and thus should not be called directly.
+
+        Args:
+            store (zarr.storage.LocalStore): local zarr storage
+            start (int): start index
+            pre_transform (Callable[[Data], Data] | None, optional): Transformation that adds additional features to the data. Defaults to None.
+            pre_filter (Callable[[Data], bool] | None, optional): A function that filters the data. Defaults to None.
+
+        Returns:
+            list[Data]: The processed data or None if the chunk is empty.
+        """
+        root = zarr.open_group(store, path="", mode="r")
+        N = int(root["num_samples"][0])
+
+        def process_item(i: int):
+            item = self.data_reader(
+                root,
+                i,
+                self.float_type,
+                self.int_type,
+                self.validate_data,
+            )
+            if pre_filter is not None and not pre_filter(item):
+                return None
+            if pre_transform is not None:
+                return pre_transform(item)
+            return item
+
+        if self.n_processes > 1:
+            results = Parallel(n_jobs=self.n_processes)(
+                delayed(process_item)(i)
+                for i in range(start, min(start + self.chunksize, N))
+            )
+        else:
+            results = [
+                process_item(i) for i in range(start, min(start + self.chunksize, N))
+            ]
+
+        return [res for res in results if res is not None]

--- a/QuantumGravPy/test/conftest.py
+++ b/QuantumGravPy/test/conftest.py
@@ -180,7 +180,6 @@ def create_data_zarr(create_data):
     path, datafiles, tmpdir, jl_generator = create_data
 
     for i in range(3):
-        print("i= ", i)
         data = jl_generator(5)
         # Save the data to an HDF5 file
         zarr_file = tmpdir / f"test_data_{i}.zarr"

--- a/QuantumGravPy/test/conftest.py
+++ b/QuantumGravPy/test/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import h5py
 import zarr
 import torch
+import numpy as np
 import torch_geometric
 from torch_geometric.data import Data
 from torch_geometric.utils import dense_to_sparse
@@ -285,7 +286,14 @@ def read_data():
         boundary = f["boundary"][idx]
         dimension = f["dimension"][idx]
 
-        value_list = [manifold.item(), boundary.item(), dimension.item()]
+        if (
+            isinstance(manifold, np.ndarray)
+            and isinstance(boundary, np.ndarray)
+            and isinstance(dimension, np.ndarray)
+        ):
+            value_list = [manifold.item(), boundary.item(), dimension.item()]
+        else:
+            value_list = [manifold, boundary, dimension]
 
         data = Data(
             x=x,

--- a/QuantumGravPy/test/test_evaluate.py
+++ b/QuantumGravPy/test/test_evaluate.py
@@ -6,8 +6,8 @@ import pytest
 
 
 @pytest.fixture
-def make_dataloader(create_data, read_data):
-    datadir, datafiles = create_data
+def make_dataloader(create_data_hdf5, read_data):
+    datadir, datafiles = create_data_hdf5
 
     dataset = QG.QGDataset(
         input=datafiles,

--- a/QuantumGravPy/test/test_inmemorydataset.py
+++ b/QuantumGravPy/test/test_inmemorydataset.py
@@ -7,12 +7,13 @@ from torch_geometric.data import Data
 
 
 @pytest.mark.parametrize("n", [1, 3], ids=["sequential", "parallel"])
-def test_inmemory_dataset_creation_and_process(create_data, read_data, n):
-    datadir, datafiles = create_data
+def test_inmemory_dataset_creation_and_process(create_data_hdf5, read_data, n):
+    datadir, datafiles = create_data_hdf5
 
     dataset = QG.QGDatasetInMemory(
         input=datafiles,
         output=datadir,
+        mode="hdf5",
         reader=read_data,
         float_type=torch.float32,
         int_type=torch.int64,
@@ -40,17 +41,50 @@ def test_inmemory_dataset_creation_and_process(create_data, read_data, n):
     assert isinstance(dataset[5], Data)
 
 
-def test_ondisk_dataset_with_dataloader(create_data, read_data):
-    datadir, datafiles = create_data
+@pytest.mark.parametrize("n", [1, 2], ids=["sequential", "parallel"])
+def test_ondisk_dataset_with_dataloader_hdf5(create_data_hdf5, read_data, n):
+    datadir, datafiles = create_data_hdf5
 
     dataset = QG.QGDatasetInMemory(
         input=datafiles,
         output=datadir,
+        mode="hdf5",
         reader=read_data,
         float_type=torch.float32,
         int_type=torch.int64,
         validate_data=True,
-        n_processes=1,
+        n_processes=n,
+        chunksize=4,
+        transform=lambda x: x,
+        pre_transform=lambda x: x,
+        pre_filter=lambda x: True,
+    )
+
+    loader = DataLoader(
+        dataset,
+        batch_size=2,
+        shuffle=True,
+    )
+    assert len(loader) == 8  # Assuming 15 samples and batch size of 2
+
+    for i, batch in enumerate(loader):
+        assert isinstance(batch, Data)
+        assert len(batch) == 2 if i < 7 else 1  # Last batch may be smaller
+
+
+@pytest.mark.parametrize("n", [1, 2], ids=["sequential", "parallel"])
+def test_ondisk_dataset_with_dataloader_zarr(create_data_zarr, read_data, n):
+    datadir, datafiles = create_data_zarr
+
+    dataset = QG.QGDatasetInMemory(
+        input=datafiles,
+        output=datadir,
+        mode="zarr",
+        reader=read_data,
+        float_type=torch.float32,
+        int_type=torch.int64,
+        validate_data=True,
+        n_processes=n,
         chunksize=4,
         transform=lambda x: x,
         pre_transform=lambda x: x,

--- a/QuantumGravPy/test/test_inmemorydataset.py
+++ b/QuantumGravPy/test/test_inmemorydataset.py
@@ -41,45 +41,24 @@ def test_inmemory_dataset_creation_and_process(create_data_hdf5, read_data, n):
     assert isinstance(dataset[5], Data)
 
 
-@pytest.mark.parametrize("n", [1, 2], ids=["sequential", "parallel"])
-def test_ondisk_dataset_with_dataloader_hdf5(create_data_hdf5, read_data, n):
-    datadir, datafiles = create_data_hdf5
+@pytest.mark.parametrize(
+    "create_data_fixture",
+    ["create_data_hdf5", "create_data_zarr"],
+    ids=["hdf5", "zarr"],
+)
+@pytest.mark.parametrize("n", [1, 3], ids=["sequential", "parallel"])
+def test_inmemory_dataset_creation_processing(
+    request, create_data_fixture, read_data, n
+):
+    create_data = request.getfixturevalue(create_data_fixture)
+
+    datadir, datafiles = create_data
+    mode = "hdf5" if create_data_fixture == "create_data_hdf5" else "zarr"
 
     dataset = QG.QGDatasetInMemory(
         input=datafiles,
         output=datadir,
-        mode="hdf5",
-        reader=read_data,
-        float_type=torch.float32,
-        int_type=torch.int64,
-        validate_data=True,
-        n_processes=n,
-        chunksize=4,
-        transform=lambda x: x,
-        pre_transform=lambda x: x,
-        pre_filter=lambda x: True,
-    )
-
-    loader = DataLoader(
-        dataset,
-        batch_size=2,
-        shuffle=True,
-    )
-    assert len(loader) == 8  # Assuming 15 samples and batch size of 2
-
-    for i, batch in enumerate(loader):
-        assert isinstance(batch, Data)
-        assert len(batch) == 2 if i < 7 else 1  # Last batch may be smaller
-
-
-@pytest.mark.parametrize("n", [1, 2], ids=["sequential", "parallel"])
-def test_ondisk_dataset_with_dataloader_zarr(create_data_zarr, read_data, n):
-    datadir, datafiles = create_data_zarr
-
-    dataset = QG.QGDatasetInMemory(
-        input=datafiles,
-        output=datadir,
-        mode="zarr",
+        mode=mode,
         reader=read_data,
         float_type=torch.float32,
         int_type=torch.int64,

--- a/QuantumGravPy/test/test_ondiskdataset.py
+++ b/QuantumGravPy/test/test_ondiskdataset.py
@@ -6,12 +6,20 @@ from torch_geometric.data import Data
 from torch_geometric.loader import DataLoader
 
 
+@pytest.mark.parametrize(
+    "create_data_fixture",
+    ["create_data_hdf5", "create_data_zarr"],
+    ids=["hdf5", "zarr"],
+)
 @pytest.mark.parametrize("n", [1, 3], ids=["sequential", "parallel"])
-def test_ondisk_dataset_creation_processing(create_data_hdf5, read_data, n):
-    datadir, datafiles = create_data_hdf5
+def test_ondisk_dataset_creation_processing(request, create_data_fixture, read_data, n):
+    create_data = request.getfixturevalue(create_data_fixture)
+    mode = "hdf5" if create_data_fixture == "create_data_hdf5" else "zarr"
+    datadir, datafiles = create_data
     dataset = QG.QGDataset(
         input=datafiles,
         output=datadir,
+        mode=mode,
         reader=read_data,
         float_type=torch.float32,
         int_type=torch.int64,
@@ -38,8 +46,8 @@ def test_ondisk_dataset_creation_processing(create_data_hdf5, read_data, n):
     assert isinstance(dataset[5], Data)
 
 
-def test_ondisk_dataset_with_dataloader(create_data, read_data):
-    datadir, datafiles = create_data
+def test_ondisk_dataset_with_dataloader(create_data_hdf5, read_data):
+    datadir, datafiles = create_data_hdf5
     dataset = QG.QGDataset(
         input=datafiles,
         output=datadir,
@@ -66,8 +74,8 @@ def test_ondisk_dataset_with_dataloader(create_data, read_data):
         assert len(batch) == 2 if i < 7 else 1  # Last batch may be smaller
 
 
-def test_ondisk_dataset_get(create_data, read_data):
-    datadir, datafiles = create_data
+def test_ondisk_dataset_get(create_data_hdf5, read_data):
+    datadir, datafiles = create_data_hdf5
     dataset = QG.QGDataset(
         input=datafiles,
         output=datadir,

--- a/QuantumGravPy/test/test_ondiskdataset.py
+++ b/QuantumGravPy/test/test_ondiskdataset.py
@@ -7,8 +7,8 @@ from torch_geometric.loader import DataLoader
 
 
 @pytest.mark.parametrize("n", [1, 3], ids=["sequential", "parallel"])
-def test_ondisk_dataset_creation_processing(create_data, read_data, n):
-    datadir, datafiles = create_data
+def test_ondisk_dataset_creation_processing(create_data_hdf5, read_data, n):
+    datadir, datafiles = create_data_hdf5
     dataset = QG.QGDataset(
         input=datafiles,
         output=datadir,


### PR DESCRIPTION
- adds support for [Zarr](https://zarr.readthedocs.io/en/stable/) files in addition to hdf5. Zarr is a more modern and simpler approach to storing N-D arrays that has better support for parallelization and is used in other ML projects for this purpose (notably in Prof. Hamprecht's group). 
Unfortunately, Julia's support is a bit more limited than Pythons, but it's enough for our purposes. 
- [x] add support on the julia side  
- [x] add julia tests 
- [x] add support on the python side 
  - [x] `dataset_base`
  - [x] `InMemoryDataset`
  - [x] `OnDiskDataset` 