### PR TITLE
- added function which generates a grid from a Brillouin cell

### DIFF
--- a/QuantumGrav.jl/src/QuantumGrav.jl
+++ b/QuantumGrav.jl/src/QuantumGrav.jl
@@ -18,6 +18,7 @@ include("layeredgeneration.jl")
 include("datageneration.jl")
 include("csetgenerationbyconnectivity.jl")
 include("destroy_manifold_like_cset.jl")
+include("grid_like_causets.jl")
 
 export make_simple_cset,
     make_manifold_cset,
@@ -31,5 +32,7 @@ export make_simple_cset,
     random_causet_by_connectivity_distribution,
     gaussian_dist_cuts,
     create_random_layered_causet,
-    destroy_manifold_cset
+    destroy_manifold_cset,
+    generate_grid_from_brillouin_cell,
+    generate_grid_2d
 end # module QuantumGrav

--- a/QuantumGrav.jl/src/grid_like_causets.jl
+++ b/QuantumGrav.jl/src/grid_like_causets.jl
@@ -1,0 +1,149 @@
+"""
+    generate_grid_from_brillouin_cell(num_atoms, edges; origin=nothing) -> Vector{CausalSets.Coordinates{N}}
+
+Construct an N‑dimensional regular grid of approximately `num_atoms` points that fills the Brillouin cell spanned by `N` edge vectors `edges`.
+
+# Arguments
+- `num_atoms::Int`: desired number of grid points (≥1). The implementation lays down a Cartesian parameter grid with ≈ `num_atoms` candidates and trims to exactly `num_atoms`.
+- `edges::NTuple{N,CausalSets.Coordinates{N}}`: the `N` spanning edge vectors of a *parallelepiped* cell. Points are of the form
+  `x = origin + sum_i t_i * edges[i]` with `t_i ∈ [0,1]`.
+- `origin`: optional `NTuple{N,Float64}` origin (vertex) of the cell. If `nothing`, zero is used.
+
+# Returns
+- `Vector{CausalSets.Coordinates{N}}`: grid points inside the cell, ordered lexicographically in the parameter tuple `(t₁,…,t_N)`, trimmed to length `num_atoms`.
+
+# Errors
+- Throws `ArgumentError` if `num_atoms < 1`.
+- Throws `ArgumentError` if the `edges` are not linearly independent (near‑zero determinant).
+"""
+function generate_grid_from_brillouin_cell(num_atoms::Int, edges::NTuple{N,CausalSets.Coordinates{N}}; origin=nothing)::Vector{CausalSets.Coordinates{N}} where {N}
+    num_atoms > 0 || throw(ArgumentError("num_atoms must be ≥ 1"))
+
+    # Normalize origin keyword (cannot parametrize keyword type with N reliably)
+    local origin_nt::NTuple{N,Float64}
+    if isnothing(origin)
+        origin_nt = ntuple(_->0.0, N)
+    else
+        origin_nt = convert(NTuple{N,Float64}, origin)
+    end
+
+    # Build edge matrix and check linear independence
+    E = Matrix{Float64}(undef, N, N)
+    for j in 1:N
+        for i in 1:N
+            E[i, j] = edges[j][i]
+        end
+    end
+    if abs(LinearAlgebra.det(E)) ≤ eps(Float64)
+        throw(ArgumentError("Brillouin-cell edges must be linearly independent (determinant ≈ 0)"))
+    end
+
+    # Choose per-dimension resolution ~ num_atoms^(1/N)
+    k = max(2, ceil(Int, num_atoms^(1/N)))
+    # total candidate points
+    total = k^N
+
+    # Parameter grids in [0,1]
+    params = ntuple(_ -> range(0.0, 1.0; length=k), N)
+
+    pts = Vector{CausalSets.Coordinates{N}}(undef, total)
+    idx = 0
+    for T in Iterators.product(params...)
+        # x = origin + E * t
+        x = Vector{Float64}(undef, N)
+        for i in 1:N
+            xi = origin_nt[i]
+            @inbounds for j in 1:N
+                xi += E[i, j] * T[j]
+            end
+            x[i] = xi
+        end
+        idx += 1
+        pts[idx] = tuple(x...)
+    end
+
+    # Trim or return exactly num_atoms
+    return length(pts) == num_atoms ? pts : pts[1:min(num_atoms, length(pts))]
+end
+
+"""
+    generate_grid_2d(num_atoms, lattice; a=1.0, b=0.5, gamma_deg=60.0, rotate_deg=nothing, origin=(0.0,0.0))
+        -> Vector{CausalSets.Coordinates{2}}
+
+Wrapper that builds a 2D Bravais cell from a lattice name and calls
+`generate_grid_from_brillouin_cell` to return `num_atoms` points.
+
+Supported `lattice` names (case‑insensitive, with aliases):
+- "square", "quadratic":         edges `((a,0), (0,a))`
+- "rectangular":                  edges `((a,0), (0,b))`
+- "centered-rectangular", "rhombic", "c-rect": primitive edges `((a/2,b/2), (a/2,-b/2))`
+- "hexagonal", "triangular":      edges `((a,0), (a/2, a*sqrt(3)/2))`
+- "oblique", "monoclinic":       edges `((a,0), (b*cosγ, b*sinγ))`, with `γ = gamma_deg` (degrees)
+
+# Keywords
+- `a::Float64=1.0`, `b::Float64=0.5`: lattice constants (for square, only `a` is used).
+- `gamma_deg::Float64=60.0`: angle (degrees) between edges for the oblique lattice.
+- `rotate_deg=nothing`: rotation (degrees) applied to the basis before grid generation. If `nothing`, an automatic rotation aligns the net growth direction `e₁+e₂` with `+y`.
+- `origin::CausalSets.Coordinates{2}=(0.0,0.0)`: origin (vertex) of the cell.
+"""
+function generate_grid_2d(num_atoms::Int, lattice::AbstractString; a::Float64=1.0, b::Float64=0.5, gamma_deg::Float64=60.0, rotate_deg=nothing, origin=(0.0,0.0))::Vector{CausalSets.Coordinates{2}}
+    lname = lowercase(strip(lattice))
+    if lname in ("square", "quadratic")
+        edges = ((a, 0.0), (0.0, a))
+    elseif lname == "rectangular"
+        edges = ((a, 0.0), (0.0, b))
+    elseif lname in ("centered-rectangular", "rhombic", "c-rect")
+        edges = ((0.5a, 0.5b), (0.5a, -0.5b))
+    elseif lname in ("hexagonal", "triangular")
+        edges = ((a, 0.0), (0.5a, 0.5a*sqrt(3.0)))
+    elseif lname in ("oblique", "monoclinic")
+        γ = deg2rad(gamma_deg)
+        edges = ((a, 0.0), (b*cos(γ), b*sin(γ)))
+    else
+        throw(ArgumentError("Unsupported 2D lattice name: '$lattice'"))
+    end
+
+    # Apply rotation: either user-provided (degrees) or auto so that (e1+e2) points upward
+    local θ::Float64
+    if isnothing(rotate_deg)
+        v = (edges[1][1] + edges[2][1], edges[1][2] + edges[2][2])
+        φ = atan(v[2], v[1])              # current angle of net growth
+        θ = (pi/2) - φ                     # rotate to +y
+    else
+        θ = deg2rad(Float64(rotate_deg))
+    end
+    c = cos(θ); s = sin(θ)
+    R = ((c, -s), (s, c))  # rotation matrix
+    rot = x -> (R[1][1]*x[1] + R[1][2]*x[2], R[2][1]*x[1] + R[2][2]*x[2])
+    edges = (rot(edges[1]), rot(edges[2]))
+
+    return generate_grid_from_brillouin_cell(num_atoms, edges; origin=origin)
+end
+
+"""
+    sort_grid_by_time_from_manifold(manifold, preset_atoms) -> Vector{CausalSets.Coordinates{N}}
+
+Stable sort of `preset_atoms` using the manifold‑provided time ordering `CausalSets.isless_coord_time`.
+Useful to impose a pseudo‑sprinkling order before constructing a causet.
+"""
+function sort_grid_by_time_from_manifold(manifold::CausalSets.AbstractManifold{N}, preset_atoms::Vector{CausalSets.Coordinates{N}})::Vector{CausalSets.Coordinates{N}} where N
+    atoms = sort(preset_atoms, lt = (x, y) -> CausalSets.isless_coord_time(manifold, x, y))
+    return atoms
+end
+
+"""
+    create_grid_causet_2D(size, lattice, manifold; a=1.0, b=0.5, gamma_deg=60.0, rotate_deg=nothing, origin=(0.0,0.0))
+        -> CausalSets.BitArrayCauset
+
+Construct a 2D grid of `size` points for the given Bravais lattice name via `generate_grid_2d`,
+sort the points by the manifold’s time ordering, and return a `BitArrayCauset` built on that order.
+
+# Keywords
+See `generate_grid_2d` for lattice parameters and rotation.
+"""
+function create_grid_causet_2D(size::Int64, lattice::AbstractString, manifold::CausalSets.AbstractManifold; a::Float64=1.0, b::Float64=0.5, gamma_deg::Float64=60.0, rotate_deg=nothing, origin=(0.0,0.0))::CausalSets.BitArrayCauset
+    grid = generate_grid_2d(size, lattice; a=a, b=b, gamma_deg=gamma_deg, rotate_deg=rotate_deg, origin=origin)
+    pseudosprinkling = sort_grid_by_time_from_manifold(manifold, grid)
+
+    return CausalSets.BitArrayCauset(manifold, pseudosprinkling)
+end

--- a/QuantumGrav.jl/test/runtests.jl
+++ b/QuantumGrav.jl/test/runtests.jl
@@ -7,4 +7,5 @@ include("./test_csetgeneration.jl")
 include("./test_csetgenerationbyconnectivity.jl")
 include("./test_layeredgeneration.jl")
 include("./test_destroy_cset.jl")
+include("./test_grid_like_causets.jl")
 @run_package_tests

--- a/QuantumGrav.jl/test/test_grid_like_causets.jl
+++ b/QuantumGrav.jl/test/test_grid_like_causets.jl
@@ -1,0 +1,135 @@
+using TestItems
+
+@testsnippet setupGridTests begin
+    using QuantumGrav
+    using CausalSets
+    using LinearAlgebra
+    using Random
+end
+
+# ---------------- Helpers (property checks) ----------------
+@testsnippet propHelpers begin
+    # Solve for barycentric parameters t in x = origin + E * t
+    function inv_map(E::AbstractMatrix{<:Real}, x::NTuple{N,Float64}, origin::NTuple{N,Float64}) where {N}
+        return tuple((E \ (collect(x) .- collect(origin)))...)
+    end
+
+    # Axis-aligned edges for expected-value tests
+    square_edges(a=1.0) = ((a,0.0),(0.0,a))
+    rect_edges(a=1.0,b=0.5) = ((a,0.0),(0.0,b))
+    hex_edges(a=1.0) = ((a,0.0),(0.5a,0.5a*sqrt(3.0)))
+
+    # Rotation matrix and rotator
+    rotmat(θ) = ((cos(θ), -sin(θ)), (sin(θ), cos(θ)))
+    rot(x, R) = (R[1][1]*x[1] + R[1][2]*x[2], R[2][1]*x[1] + R[2][2]*x[2])
+end
+
+# ---------------- generate_grid_from_brillouin_cell ----------------
+@testitem "brillouin_cell_points_in_unit_param_cube" tags=[:cell,:props] setup=[setupGridTests, propHelpers] begin
+    edges = square_edges(1.0)
+    origin = (0.0,0.0)
+    pts = QuantumGrav.generate_grid_from_brillouin_cell(25, edges; origin=origin)
+    @test length(pts) == 25
+    E = [edges[1][1] edges[2][1]; edges[1][2] edges[2][2]]
+    for p in pts
+        t = inv_map(E, p, origin)
+        @test all(0.0 - 1e-12 .<= t .<= 1.0 + 1e-12)
+    end
+end
+
+@testitem "degenerate_edges_throw" tags=[:cell,:errors] setup=[setupGridTests] begin
+    edges = ((1.0,0.0),(2.0,0.0))
+    @test_throws ArgumentError QuantumGrav.generate_grid_from_brillouin_cell(10, edges)
+end
+
+@testitem "square_expected_small_grids" tags=[:cell,:expected] setup=[setupGridTests] begin
+    # k=2 (4 points)
+    edges = ((1.0,0.0),(0.0,1.0))
+    pts4 = QuantumGrav.generate_grid_from_brillouin_cell(4, edges)
+    @test Set(pts4) == Set([(0.0,0.0),(1.0,0.0),(0.0,1.0),(1.0,1.0)])
+    # k=3 (9 points)
+    pts9 = QuantumGrav.generate_grid_from_brillouin_cell(9, edges)
+    expected9 = Tuple{Float64,Float64}[]
+    for i in 0:2, j in 0:2
+        push!(expected9, (i/2, j/2))
+    end
+    @test Set(pts9) == Set(expected9)
+end
+
+@testitem "rotation_equivariance" tags=[:cell,:props] setup=[setupGridTests, propHelpers] begin
+    edges = rect_edges(2.0, 1.0)
+    origin = (0.1,-0.2)
+    pts = QuantumGrav.generate_grid_from_brillouin_cell(16, edges; origin=origin)
+    θ = 0.37
+    R = rotmat(θ)
+    redges = (rot(edges[1],R), rot(edges[2],R))
+    rorigin = rot(origin,R)
+    rpts = QuantumGrav.generate_grid_from_brillouin_cell(16, redges; origin=rorigin)
+    @test length(rpts) == 16
+    # The rotated set should equal pointwise rotation of original (order preserved by our construction)
+    for (p, q) in zip(pts, rpts)
+        @test isapprox(rot(p,R)[1], q[1]; atol=1e-12)
+        @test isapprox(rot(p,R)[2], q[2]; atol=1e-12)
+    end
+end
+
+# ---------------- generate_grid_2d (wrapper) ----------------
+@testitem "wrapper_square_expected_values" tags=[:wrapper,:expected] setup=[setupGridTests] begin
+    pts = QuantumGrav.generate_grid_2d(9, "square"; a=1.0, rotate_deg=0)
+    expected9 = Tuple{Float64,Float64}[]
+    for i in 0:2, j in 0:2
+        push!(expected9, (i/2, j/2))
+    end
+    @test Set(pts) == Set(expected9)
+end
+
+@testitem "wrapper_rectangular_expected_values" tags=[:wrapper,:expected] setup=[setupGridTests] begin
+    pts = QuantumGrav.generate_grid_2d(9, "rectangular"; a=2.0, b=1.0, rotate_deg=0)
+    expected9 = Tuple{Float64,Float64}[]
+    for i in 0:2, j in 0:2
+        push!(expected9, (i/2*2.0, j/2*1.0))
+    end
+    @test Set(pts) == Set(expected9)
+end
+
+@testitem "wrapper_hexagonal_expected_values" tags=[:wrapper,:expected] setup=[setupGridTests, propHelpers] begin
+    pts = QuantumGrav.generate_grid_2d(9, "hexagonal"; a=1.0, rotate_deg=0)
+    expected9 = Tuple{Float64,Float64}[]
+    ts = (0.0, 0.5, 1.0)
+    e1, e2 = hex_edges(1.0)
+    for t1 in ts, t2 in ts
+        push!(expected9, (t1*e1[1] + t2*e2[1], t1*e1[2] + t2*e2[2]))
+    end
+    @test Set(pts) == Set(expected9)
+end
+
+@testitem "wrapper_auto_rotation_prefers_y_extent" tags=[:wrapper,:props] setup=[setupGridTests] begin
+    pts = QuantumGrav.generate_grid_2d(40, "rectangular"; a=2.0, b=0.5)  # auto-rotate
+    xs = first.(pts); ys = last.(pts)
+    @test (maximum(ys) - minimum(ys)) ≥ (maximum(xs) - minimum(xs))
+end
+
+@testitem "wrapper_bad_name_throws" tags=[:wrapper,:errors] setup=[setupGridTests] begin
+    @test_throws ArgumentError QuantumGrav.generate_grid_2d(5, "not-a-lattice")
+end
+
+# ---------------- sort_grid_by_time_from_manifold ----------------
+@testitem "ordering_is_monotone" tags=[:ordering] setup=[setupGridTests] begin
+    grid = QuantumGrav.generate_grid_2d(25, "square"; a=1.0, rotate_deg=0)
+    sorted = QuantumGrav.sort_grid_by_time_from_manifold(CausalSets.MinkowskiManifold{2}(), grid)
+    ok = true
+    for i in 1:length(sorted)-1
+        if CausalSets.isless_coord_time(CausalSets.MinkowskiManifold{2}(), sorted[i+1], sorted[i])
+            ok = false; break
+        end
+    end
+    @test ok
+end
+
+# ---------------- create_grid_causet_2D ----------------
+@testitem "grid_ordering_consistent_with_coordinate_time_order" tags=[:cset] setup=[setupGridTests] begin
+    grid = QuantumGrav.generate_grid_2d(30, "square"; a=1.0, rotate_deg=0)
+    cset = QuantumGrav.create_grid_causet_2D(30, "square", CausalSets.MinkowskiManifold{2}(); a=1.0, rotate_deg=0)
+    @test typeof(cset) == CausalSets.BitArrayCauset
+    @test cset.atom_count == 30
+end


### PR DESCRIPTION
- added function which generates a 2D grid from a string identifying the grid type and rotates it if required 
(there are 5 types of grids in 2D: square, rectangle, hexagonal, rhombic and oblique)
- added function which turns grid into (pseudo)sprinkling to be used by CausalSets
- added function which creates 2D grid causet from string identifying grid type and rotation angle