### PR TITLE
projection layer args and kwargs to make it more flexible when differ…

### DIFF
--- a/QuantumGravPy/src/QuantumGrav/gnn_block.py
+++ b/QuantumGravPy/src/QuantumGrav/gnn_block.py
@@ -21,12 +21,14 @@ class GNNBlock(torch.nn.Module):
         gnn_layer_type: torch.nn.Module = tgnn.conv.GCNConv,
         normalizer: torch.nn.Module = torch.nn.Identity,
         activation: torch.nn.Module = torch.nn.ReLU,
-        gnn_layer_args: list[Any] = None,
-        gnn_layer_kwargs: dict[str, Any] = None,
-        norm_args: list[Any] = None,
-        norm_kwargs: dict[str, Any] = None,
-        activation_args: list[Any] = None,
-        activation_kwargs: dict[str, Any] = None,
+        gnn_layer_args: list[Any] | None = None,
+        gnn_layer_kwargs: dict[str, Any] | None = None,
+        norm_args: list[Any] | None = None,
+        norm_kwargs: dict[str, Any] | None = None,
+        activation_args: list[Any] | None = None,
+        activation_kwargs: dict[str, Any] | None = None,
+        projection_args: list[Any] | None = None,
+        projection_kwargs: dict[str, Any] | None = None,
     ):
         """Create a GNNBlock instance.
 
@@ -43,6 +45,9 @@ class GNNBlock(torch.nn.Module):
             norm_kwargs (dict[str, Any], optional): Additional keyword arguments for the normalizer layer. Defaults to None.
             activation_args (list[Any], optional): Additional arguments for the activation function. Defaults to None.
             activation_kwargs (dict[str, Any], optional): Additional keyword arguments for the activation function. Defaults to None.
+            projection_args (list[Any], optional): Additional arguments for the projection layer. Defaults to None.
+            projection_kwargs (dict[str, Any], optional): Additional keyword arguments for the projection layer. Defaults to None.
+
         """
         super().__init__()
 
@@ -72,7 +77,10 @@ class GNNBlock(torch.nn.Module):
         )
 
         if in_dim != out_dim:
-            self.projection = torch.nn.Linear(in_dim, out_dim)
+            self.projection = torch.nn.Linear(
+                *(projection_args if projection_args is not None else []),
+                **(projection_kwargs if projection_kwargs is not None else {}),
+            )
         else:
             self.projection = torch.nn.Identity()
 
@@ -129,6 +137,8 @@ class GNNBlock(torch.nn.Module):
             norm_kwargs=config.get("norm_kwargs", {}),
             activation_args=config.get("activation_args", []),
             activation_kwargs=config.get("activation_kwargs", {}),
+            projection_args=config.get("projection_args", []),
+            projection_kwargs=config.get("projection_kwargs", {}),
         )
 
     def save(self, path: str | Path) -> None:

--- a/QuantumGravPy/src/QuantumGrav/gnn_model.py
+++ b/QuantumGravPy/src/QuantumGrav/gnn_model.py
@@ -142,6 +142,7 @@ class GNNModel(torch.nn.Module):
         graph_features_net = (
             QGF.GraphFeaturesBlock.from_config(config["graph_features_net"])
             if "graph_features_net" in config
+            and config["graph_features_net"] is not None
             else torch.nn.Identity()
         )
 

--- a/QuantumGravPy/test/conftest.py
+++ b/QuantumGravPy/test/conftest.py
@@ -344,6 +344,8 @@ def gnn_block():
             32,
         ],
         norm_kwargs={"eps": 1e-5, "momentum": 0.2},
+        projection_args=[16, 32],
+        projection_kwargs={"bias": False},
     )
 
 
@@ -445,6 +447,10 @@ def model_config_eval():
                     8,
                 ],
                 "norm_kwargs": {"eps": 1e-5, "momentum": 0.2},
+                "projection_args": [2, 8],
+                "projection_kwargs": {
+                    "bias": False,
+                },
                 "gnn_layer_kwargs": {
                     "cached": False,
                     "bias": True,
@@ -462,6 +468,10 @@ def model_config_eval():
                     12,
                 ],
                 "norm_kwargs": {"eps": 1e-5, "momentum": 0.2},
+                "projection_args": [8, 12],
+                "projection_kwargs": {
+                    "bias": False,
+                },
                 "gnn_layer_kwargs": {
                     "cached": False,
                     "bias": True,

--- a/QuantumGravPy/test/test_gnn_block.py
+++ b/QuantumGravPy/test/test_gnn_block.py
@@ -19,6 +19,10 @@ def gnn_block_config():
             32,
         ],
         "norm_kwargs": {"eps": 1e-5, "momentum": 0.2},
+        "projection_args": [16, 32],
+        "projection_kwargs": {
+            "bias": False,
+        },
         "gnn_layer_kwargs": {"cached": False, "bias": True, "add_self_loops": True},
     }
 

--- a/QuantumGravPy/test/test_gnn_model.py
+++ b/QuantumGravPy/test/test_gnn_model.py
@@ -45,6 +45,8 @@ def gnn_model_config():
                     32,
                 ],
                 "norm_kwargs": {"eps": 1e-5, "momentum": 0.2},
+                "projection_args": [16, 32],
+                "projection_kwargs": {"bias": False},
                 "gnn_layer_kwargs": {
                     "cached": False,
                     "bias": True,
@@ -62,6 +64,8 @@ def gnn_model_config():
                     16,
                 ],
                 "norm_kwargs": {"eps": 1e-5, "momentum": 0.2},
+                "projection_args": [32, 16],
+                "projection_kwargs": {"bias": False},
                 "gnn_layer_kwargs": {
                     "cached": False,
                     "bias": True,


### PR DESCRIPTION
- add args, kwargs for the projection layer in the `gnn_block` class 
- this is necessary b/c for some layers (e.g `GatConv`) have outputs of size outputsize * num_attention-heads or some things like that, so the current input-output dimension based approach didn´t capture that anymore. 