### PR TITLE
Bugfix for merging csets

### DIFF
--- a/QuantumGrav.jl/src/csetmerging.jl
+++ b/QuantumGrav.jl/src/csetmerging.jl
@@ -203,13 +203,13 @@ function insert_KR_into_manifoldlike(
 
     n2_rel <= 0 && throw(ArgumentError("n2_rel must be larger than 0, is $n2_rel."))
     
-    n2 = max(3, round(Int, n2_rel * npoints))  # Ensure at least 3
+    n2 = max(4, round(Int, n2_rel * npoints))  # Ensure at least 4
 
     n1 = max(1, npoints - n2) # Ensure at least 1
 
     cset1Raw, _, _ =
         make_polynomial_manifold_cset(n1, rng, order, r; d = d, type = type)
-        
+
     cset2Raw, _ = create_random_layered_causet(n2, 3; p = p)
 
     return insert_cset(


### PR DESCRIPTION
- changed minimal number of points in KR order to 3 when merging with manifoldlike; this is necessary by consistency (3 layers require 3 points)